### PR TITLE
README: add `--unstable` and `--allow-*` options to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Donwload the dim from binary files.
 or
 
 ```
-deno install dim.ts
+deno install --unstable --allow-read --allow-write --allow-net dim.ts
 ```
 
 ## Setup the project


### PR DESCRIPTION
When I tried to install the software as described in README.md, I got the some error.

```
error: TS2339 [ERROR]: Property 'utime' does not exist on type 'typeof Deno'. 'Deno.utime' is an unstable API. Did you forget to run with the '--unstable' flag?
    await Deno.utime(dest, statInfo.atime, statInfo.mtime);
               ~~~~~
    at https://deno.land/std@0.104.0/fs/copy.ts:96:16

TS2339 [ERROR]: Property 'utimeSync' does not exist on type 'typeof Deno'. 'Deno.utimeSync' is an unstable API. Did you forget to run with the '--unstable' flag?
    Deno.utimeSync(dest, statInfo.atime, statInfo.mtime);
         ~~~~~~~~~
    at https://deno.land/std@0.104.0/fs/copy.ts:111:10
(snip)
```

So I added the options to the installation description in README.md, which I was actually able to install.

I also added `--allow-read` and other options, because it seemed to cause an error at runtime without it (I don't know if this is enough or not).

### deno version

```
deno 1.17.2 (release, x86_64-apple-darwin)
v8 9.7.106.15
typescript 4.5.2
```