### PR TITLE
Fix help messages; do not override default style for `install` and `uninstall`

### DIFF
--- a/dim.ts
+++ b/dim.ts
@@ -36,17 +36,19 @@ await new Command()
         "-n, --name [name]",
         "Specify the name.",
       )
-      .description("Install the data.")
-      .help(
-        "Specify the url of data. If you dont't specify argument, install all data which is not installed dependency.",
+      .description(
+        "Install the data.\n" +
+          "Specify the url of data. If you dont't specify argument, install all data which is not installed dependency.",
       )
       .action(new InstallAction().execute),
   )
   .command(
     "uninstall <url:string>",
     new Command()
-      .description("Uninstall the data.")
-      .help("Specify the data name or data url.")
+      .description(
+        "Uninstall the data.\n" +
+          "Specify the data name or data url.",
+      )
       .action(new UninstallAction().execute),
   )
   .command(


### PR DESCRIPTION
Before:

```console
$ deno run --unstable --allow-read --allow-write --allow-run --allow-net dim.ts help install
Check file:///Users/maki/git/dim/dim.ts
Specify the url of data. If you dont't specify argument, install all data which is not installed dependency.
```

After:

```console
$ deno run --unstable --allow-read --allow-write --allow-run --allow-net dim.ts help install
Check file:///Users/maki/git/dim/dim.ts

  Usage:   dim install [url:string]
  Version: 0.1.1                   

  Description:

    Install the data.                                                                                           
    Specify the url of data. If you dont't specify argument, install all data which is not installed dependency.

  Options:

    -h, --help                      - Show this help.                          
    -p, --preprocess  <preprocess>  - Specify pre-processing when installing.  
    -n, --name        [name]        - Specify the name.                        
```
