### PR TITLE
Simple format option (--simple) in list action

### DIFF
--- a/dim.ts
+++ b/dim.ts
@@ -55,6 +55,10 @@ await new Command()
   .command(
     "list",
     new Command()
+      .option(
+        "-s, --simple",
+        "Simple format.",
+      )
       .description("Show the data list.")
       .action(new ListAction().execute),
   )

--- a/libs/actions.ts
+++ b/libs/actions.ts
@@ -235,29 +235,40 @@ export class UninstallAction {
 }
 
 export class ListAction {
-  execute(options: any): void {
+  execute(
+    options: { simple: boolean }
+  ): void {
     const contents = new DimLockFileAccessor().getContents();
     contents.forEach((content) => {
-      console.log(
-        content.name,
-      );
-      console.log(
-        "  - URL       :",
-        Colors.green(content.url),
-      );
-      console.log(
-        "  - Name      :",
-        Colors.green(content.name),
-      );
-      console.log(
-        "  - File path :",
-        Colors.green(content.path),
-      );
-      console.log(
-        "  - Preprocess:",
-        Colors.green(content.preprocesses.join(", ")),
-      );
-      console.log();
+      if (options.simple == true) {
+        console.log(
+          content.name,
+          content.url,
+          content.path,
+          content.preprocesses.join(",")
+        );
+      } else {
+        console.log(
+          content.name,
+        );
+        console.log(
+          "  - URL       :",
+          Colors.green(content.url),
+        );
+        console.log(
+          "  - Name      :",
+          Colors.green(content.name),
+        );
+        console.log(
+          "  - File path :",
+          Colors.green(content.path),
+        );
+        console.log(
+          "  - Preprocess:",
+          Colors.green(content.preprocesses.join(", ")),
+        );
+        console.log();
+      }
     });
   }
 }


### PR DESCRIPTION
シェルのパイプに流すためにlistのシンプル表示オプション(--simple)を追加。
以下は実行例。

```
#
# サンプルオープンデータのインストール
#

$ dim init
Initialized the project for the dim.

$ dim install https://data.odp.jig.jp/viewcsv/jp/tokyo/shinjuku/715.csv -n 避難所情報
Installed to ./data_files/data.odp.jig.jp/viewcsv/jp/tokyo/shinjuku/715.csv

$ dim install https://www.tomin-anzen.metro.tokyo.lg.jp/kotsu/churinjou.csv -n 自転車駐輪場情報
Installed to ./data_files/www.tomin-anzen.metro.tokyo.lg.jp/kotsu/churinjou.csv

$ dim list
避難所情報
  - URL       : https://data.odp.jig.jp/viewcsv/jp/tokyo/shinjuku/715.csv
  - Name      : 避難所情報
  - File path : ./data_files/data.odp.jig.jp/viewcsv/jp/tokyo/shinjuku/715.csv
  - Preprocess:

自転車駐輪場情報
  - URL       : https://www.tomin-anzen.metro.tokyo.lg.jp/kotsu/churinjou.csv
  - Name      : 自転車駐輪場情報
  - File path : ./data_files/www.tomin-anzen.metro.tokyo.lg.jp/kotsu/churinjou.csv
  - Preprocess:

#
# dim listの--simpleオプションによるパイプライン例
#

# 基本コマンド

$ dim list --simple
避難所情報 https://data.odp.jig.jp/viewcsv/jp/tokyo/shinjuku/715.csv ./data_files/data.odp.jig.jp/viewcsv/jp/tokyo/shinjuku/715.csv
自転車駐輪場情報 https://www.tomin-anzen.metro.tokyo.lg.jp/kotsu/churinjou.csv ./data_files/www.tomin-anzen.metro.tokyo.lg.jp/kotsu/churinjou.csv

# grep, cutに流してfile pathを取り出す

$ dim list -s | grep 避難所情報 | cut -d' ' -f3
./data_files/data.odp.jig.jp/viewcsv/jp/tokyo/shinjuku/715.csv

# grep, cutに流して得たfile pathの中身をheadで確認する

$ head -2 `dim list -s | grep 避難所情報 | cut -d' ' -f3`
﻿施設名,施設名(英語),カテゴリ,都道府県名,市区町村名,行政区名,住所,住所(かな),電話番号,対象地区,対象に対する記述,緯度,経度,海抜(m),避難所高さ(m),許容人数,洪水対応,土砂災害対応,高潮対応,地震対応,津波対応,浸水対応,大火事対応,噴火対応,説明(日 本語),説明(英語),標準地域コード
四谷小学校,"",避難所,東京都,新宿区,"",四谷2-6,"","",市谷本村町町会（箪笥町地域）､坂町町会､三栄町町会､本塩町町会､四谷二丁目町会,"",35.68671,139.72546,"","","","","","","","","","","","","",http://statdb.nstac.go.jp/lod/sac/C13104
```